### PR TITLE
Muting 'Applause' after leaving resultscreen closes #27

### DIFF
--- a/src/itdelatrisu/opsu/audio/MultiClip.java
+++ b/src/itdelatrisu/opsu/audio/MultiClip.java
@@ -235,4 +235,14 @@ public class MultiClip {
 		// reset extra clip count
 		extraClips = 0;
 	}
+
+    /**
+     * Mute the Clip (because destroying it, won't stop it)
+     */
+    public void mute() {
+        try {
+            ((FloatControl) getClip().getControl(FloatControl.Type.MASTER_GAIN)).setValue((float) (Math.log(Float.MIN_VALUE) / Math.log(10.0) * 20.0));
+        } catch (Exception e) {
+        }
+    }
 }

--- a/src/itdelatrisu/opsu/audio/SoundController.java
+++ b/src/itdelatrisu/opsu/audio/SoundController.java
@@ -44,7 +44,8 @@ import org.newdawn.slick.util.ResourceLoader;
  * Note: Uses Java Sound because OpenAL lags too much for accurate hit sounds.
  */
 public class SoundController {
-	/** Interface for all (non-music) sound components. */
+
+    /** Interface for all (non-music) sound components. */
 	public interface SoundComponent {
 		/**
 		 * Returns the Clip associated with the sound component.
@@ -55,6 +56,9 @@ public class SoundController {
 
 	/** The current track being played, if any. */
 	private static MultiClip currentTrack;
+
+    /** The current SoundComponent being played, if any */
+    private static MultiClip currentSoundComponent;
 
 	/** Sample volume multiplier, from timing points [0, 1]. */
 	private static float sampleVolumeMultiplier = 1f;
@@ -264,6 +268,8 @@ public class SoundController {
 		if (clip == null)  // clip failed to load properly
 			return;
 
+        currentSoundComponent = clip;
+
 		if (volume > 0f && !isMuted) {
 			try {
 				clip.start(volume, listener);
@@ -378,4 +384,11 @@ public class SoundController {
 			currentTrack = null;
 		}
 	}
+
+    public static void muteSoundComponent() {
+        if (currentSoundComponent != null) {
+            currentSoundComponent.mute();
+            currentSoundComponent = null;
+        }
+    }
 }

--- a/src/itdelatrisu/opsu/states/GameRanking.java
+++ b/src/itdelatrisu/opsu/states/GameRanking.java
@@ -240,6 +240,7 @@ public class GameRanking extends BasicGameState {
 	 * Returns to the song menu.
 	 */
 	private void returnToSongMenu() {
+        SoundController.muteSoundComponent();
 		SoundController.playSound(SoundEffect.MENUBACK);
 		SongMenu songMenu = (SongMenu) game.getState(Opsu.STATE_SONGMENU);
 		if (data.isGameplay())


### PR DESCRIPTION
Apparently muting is the only way to stop it.
Destroying the source will crash the game and won't stop it from playing 